### PR TITLE
Connecting pest detections to parcels

### DIFF
--- a/digitaltwin/utils/data_adapter.py
+++ b/digitaltwin/utils/data_adapter.py
@@ -243,7 +243,6 @@ def map_pest_detections_to_device_id(
     return pest_map
 
 
-# TODO: WIP
 def map_pest_detections_to_parcel(
         parcel_area: GeoJSON,
         pests: agri_food_model.AgriPest,

--- a/digitaltwin/utils/data_adapter.py
+++ b/digitaltwin/utils/data_adapter.py
@@ -3,6 +3,7 @@ from geojson import (
     Polygon,
     MultiLineString,
     Point,
+    MultiPoint,
     Feature,
     FeatureCollection,
 )
@@ -212,6 +213,32 @@ def get_coordinates(
             coords = feature["geometry"]["coordinates"]
             multi_line_string_coords.append(coords)
     return multi_line_string_coords
+
+
+def map_pest_locations_to_id(
+        pests: list[agri_food_model.AgriPest],
+        pest_locations: dict[str, MultiPoint],
+) -> dict:
+    pest_map = {}
+    for pest in pests:
+        if pest.description in pest_locations:
+            pest_map[pest.id] = pest_locations[pest.description]
+    return pest_map
+
+
+# TODO: WIP
+def map_pest_locations_to_parcel(
+        parcel: agri_food_model.AgriParcel,
+        pest_locations: dict[str, MultiPoint],
+) -> dict:
+
+    pest_map = {}
+    for pest, location in pest_locations.items():
+        if location in parcel.location.Polygon:
+            pest_map[pest] = location
+
+    return pest_map
+
 
 
 def fill_database(variables: list[str] = get_default_variables()):

--- a/digitaltwin/vision.py
+++ b/digitaltwin/vision.py
@@ -19,8 +19,9 @@ from digitaltwin.utils.data_adapter import (
     get_coordinates,
     fill_database,
     fill_database_ascab,
-    map_pest_locations_to_id,
-    map_pest_locations_to_parcel
+    map_pest_detections_to_device_id,
+    map_pest_detections_to_parcel,
+    check_points_in_parcel
 )
 from digitaltwin.cropmodel.crop_model import get_default_variables
 
@@ -87,17 +88,16 @@ def main():
         # Option 1: a single score per parcel
         score = get_detection_score_in_parcel(parcel_area)
         # Option 2: get locations of detections within the given parcel
-        locations = get_locations_of_detections()
-        locations_pests = get_demo_pest_location()
+        # locations = get_locations_of_detections()
+        pest_detections = get_demo_pest_location()
 
         crop = get_by_id(parcel.hasAgriCrop["object"])
-        pest = [get_by_id(pest_id) for pest_id in crop.hasAgriPest["object"]]
-        devices = [find_device(p.id) for p in pest]
+        pests = [get_by_id(pest_id) for pest_id in crop.hasAgriPest["object"]]
+        devices = [find_device(p.id) for p in pests]
         #  Flatten the devices list
         devices = [device for sublist in devices for device in sublist]
         #  Maps detection locations to pest
-        # pest_map = map_pest_locations_to_parcel(parcel, locations_pests)
-        pest_map = map_pest_locations_to_id(pest, locations_pests)
+        pest_map = map_pest_detections_to_device_id(pests, pest_detections)
         #  the device (with its device measurements) is linked to a pest
         #  the pest is linked to a crop (that is linked to a given parcel)
         device_dict = {device.controlledProperty: device for device in devices}
@@ -109,17 +109,30 @@ def main():
                     device=device,
                     date_observed=datetime.utcnow().isoformat() + "Z",
                     value=score,
-                    location=pest_map[device.controlledAsset],
+                    # location=pest_map[device.controlledAsset],  # can use either this option `detections->device->pest id`
+                    location=map_pest_detections_to_parcel(  # or this option `detections->parcel area->device->pest id`
+                        parcel_area,
+                        pests,
+                        device,
+                        pest_detections
+                    )
                 )
             # Option 2
             if variable == "obs-detections":
-                print(f"save detections {locations}")
+                print(f"save detections {pest_detections}")
                 detection_object = create_device_measurement(
                     device=device,
                     date_observed=datetime.utcnow().isoformat() + "Z",
                     value=1.0,
-                    location=pest_map[device.controlledAsset],
+                    # location=pest_map[device.controlledAsset],
+                    location=map_pest_detections_to_parcel(
+                        parcel_area,
+                        pests,
+                        device,
+                        pest_detections
+                    )
                 )
+                print(detection_object)
     print("The following DeviceMeasurements were stored:\n")
     obs_scores = search(
         {

--- a/digitaltwin/vision.py
+++ b/digitaltwin/vision.py
@@ -36,6 +36,24 @@ def get_locations_of_detections() -> MultiPoint:
     return multi_point
 
 
+def get_locations_of_detections_ascab() -> MultiPoint:
+    coordinates_detections = [
+        (3.0936112, 42.1625702),
+        (3.0945098, 42.1619982),
+    ]
+    multi_point = MultiPoint(coordinates_detections)
+    return multi_point
+
+
+def get_locations_of_detections_apple_alternaria() -> MultiPoint:
+    coordinates_detections = [
+        (3.0936112, 42.1623702),
+        (3.0945098, 42.1620982),
+    ]
+    multi_point = MultiPoint(coordinates_detections)
+    return multi_point
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -60,8 +78,10 @@ def main():
         # Option 2: get locations of detections within the given parcel
         locations = get_locations_of_detections()
         crop = get_by_id(parcel.hasAgriCrop["object"])
-        pest = get_by_id(crop.hasAgriPest["object"])
-        devices = find_device(pest.id)
+        pest = [get_by_id(pest_id) for pest_id in crop.hasAgriPest["object"]]
+        devices = [find_device(p.id) for p in pest]
+        #  Flatten the devices list
+        devices = [device for sublist in devices for device in sublist]
         #  the device (with its device measurements) is linked to a pest
         #  the pest is linked to a crop (that is linked to a given parcel)
         device_dict = {device.controlledProperty: device for device in devices}

--- a/digitaltwin/vision.py
+++ b/digitaltwin/vision.py
@@ -51,8 +51,8 @@ def get_locations_of_detections_ascab() -> MultiPoint:
 
 def get_locations_of_detections_apple_alternaria() -> MultiPoint:
     coordinates_detections = [
-        (3.0936112, 42.1623702),
-        (3.0945098, 42.1620982),
+        (3.0956322, 42.1615223),
+        (3.0935098, 42.1622142),
     ]
     multi_point = MultiPoint(coordinates_detections)
     return multi_point

--- a/digitaltwin/vision.py
+++ b/digitaltwin/vision.py
@@ -18,6 +18,9 @@ from digitaltwin.utils.data_adapter import (
     create_device_measurement,
     get_coordinates,
     fill_database,
+    fill_database_ascab,
+    map_pest_locations_to_id,
+    map_pest_locations_to_parcel
 )
 from digitaltwin.cropmodel.crop_model import get_default_variables
 
@@ -54,6 +57,13 @@ def get_locations_of_detections_apple_alternaria() -> MultiPoint:
     return multi_point
 
 
+def get_demo_pest_location() -> dict[str, MultiPoint]:
+    return {
+        'alternaria': get_locations_of_detections_apple_alternaria(),
+        'ascab': get_locations_of_detections_ascab()
+    }
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -67,9 +77,10 @@ def main():
 
     # fill database with demo data
     if not has_demodata():
-        fill_database(variables=get_default_variables())
+        # fill_database(variables=get_default_variables())
+        fill_database_ascab()
 
-    parcels = search(get_demo_parcels(), ctx=AgriFood.ctx)
+    parcels = search(get_demo_parcels("Serrater"), ctx=AgriFood.ctx)
 
     for parcel in parcels:
         parcel_area = get_coordinates(parcel.location, "Polygon")
@@ -77,11 +88,16 @@ def main():
         score = get_detection_score_in_parcel(parcel_area)
         # Option 2: get locations of detections within the given parcel
         locations = get_locations_of_detections()
+        locations_pests = get_demo_pest_location()
+
         crop = get_by_id(parcel.hasAgriCrop["object"])
         pest = [get_by_id(pest_id) for pest_id in crop.hasAgriPest["object"]]
         devices = [find_device(p.id) for p in pest]
         #  Flatten the devices list
         devices = [device for sublist in devices for device in sublist]
+        #  Maps detection locations to pest
+        # pest_map = map_pest_locations_to_parcel(parcel, locations_pests)
+        pest_map = map_pest_locations_to_id(pest, locations_pests)
         #  the device (with its device measurements) is linked to a pest
         #  the pest is linked to a crop (that is linked to a given parcel)
         device_dict = {device.controlledProperty: device for device in devices}
@@ -89,19 +105,20 @@ def main():
         for variable, device in device_dict.items():
             # Option 1
             if variable == "obs-detection_score":
-                create_device_measurement(
+                score_object = create_device_measurement(
                     device=device,
                     date_observed=datetime.utcnow().isoformat() + "Z",
                     value=score,
+                    location=pest_map[device.controlledAsset],
                 )
             # Option 2
             if variable == "obs-detections":
                 print(f"save detections {locations}")
-                create_device_measurement(
+                detection_object = create_device_measurement(
                     device=device,
                     date_observed=datetime.utcnow().isoformat() + "Z",
                     value=1.0,
-                    location=locations,
+                    location=pest_map[device.controlledAsset],
                 )
     print("The following DeviceMeasurements were stored:\n")
     obs_scores = search(

--- a/digitaltwin/vision.py
+++ b/digitaltwin/vision.py
@@ -97,7 +97,7 @@ def main():
         #  Flatten the devices list
         devices = [device for sublist in devices for device in sublist]
         #  Maps detection locations to pest
-        pest_map = map_pest_detections_to_device_id(pests, pest_detections)
+        pest_map = map_pest_detections_to_device_id(pests, pest_detections)  # uncomment for id method
         #  the device (with its device measurements) is linked to a pest
         #  the pest is linked to a crop (that is linked to a given parcel)
         device_dict = {device.controlledProperty: device for device in devices}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ uvicorn = "^0.31.1"
 matplotlib = "^3.9.2"
 datetime = "^5.5"
 nlopt = "2.7.1"
+shapely = "2.0.7"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
I made two methods for associating a pest detection to a parcel. Could discuss which method is preferred.

Some specific changes:
- AgriPest now must always be a list when creating AgriCrop
- Changed `get_coordinates()` output to a GeoJSON type
- To associate device measurement to each parcel, can either use option "map pest description to pest id" or "map pest detections to parcels". Details in the code.
- using the second method, the shapely package must be installed: changes to Poetry.